### PR TITLE
Add InitializeCollectionExtensions

### DIFF
--- a/Packages/UGF.Initialize/Runtime/InitializeCollectionExtensions.cs
+++ b/Packages/UGF.Initialize/Runtime/InitializeCollectionExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace UGF.Initialize.Runtime
+{
+    public static class InitializeCollectionExtensions
+    {
+        public static T Create<T>(this IInitializeCollection collection, T element) where T : class, IInitialize
+        {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            collection.Add(element);
+
+            return element;
+        }
+
+        public static T Get<TArguments, T>(this IInitializeCollection collection, TArguments arguments, InitializeCollectionPredicate<TArguments, T> predicate) where T : class, IInitialize
+        {
+            return TryGet(collection, arguments, predicate, out T value) ? value : throw new ArgumentException($"Value not found by the specified arguments: '{arguments}'.");
+        }
+
+        public static bool TryGet<TArguments, T>(this IInitializeCollection collection, TArguments arguments, InitializeCollectionPredicate<TArguments, T> predicate, out T value) where T : class, IInitialize
+        {
+            if (collection == null) throw new ArgumentNullException(nameof(collection));
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                value = collection[i] as T;
+
+                if (predicate(arguments, value))
+                {
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/Packages/UGF.Initialize/Runtime/InitializeCollectionExtensions.cs.meta
+++ b/Packages/UGF.Initialize/Runtime/InitializeCollectionExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7e75a32331084bb1a10b6b7909e4678a
+timeCreated: 1637690636

--- a/Packages/UGF.Initialize/Runtime/InitializeCollectionPredicate.cs
+++ b/Packages/UGF.Initialize/Runtime/InitializeCollectionPredicate.cs
@@ -1,0 +1,4 @@
+﻿namespace UGF.Initialize.Runtime
+{
+    public delegate bool InitializeCollectionPredicate<in TArguments, in TValue>(TArguments arguments, TValue value) where TValue : class, IInitialize;
+}

--- a/Packages/UGF.Initialize/Runtime/InitializeCollectionPredicate.cs.meta
+++ b/Packages/UGF.Initialize/Runtime/InitializeCollectionPredicate.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b09730543a54ec58c9408cf98dae750
+timeCreated: 1637690666

--- a/Packages/UGF.Initialize/package.json
+++ b/Packages/UGF.Initialize/package.json
@@ -17,5 +17,6 @@
   "licensesUrl": "https://github.com/unity-game-framework/ugf-initialize/blob/master/license",
   "publishConfig": {
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
-  }
+  },
+  "dependencies": {}
 }

--- a/Packages/UGF.Initialize/package.json
+++ b/Packages/UGF.Initialize/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.initialize",
   "displayName": "UGF.Initialize",
   "version": "2.6.0",
-  "unity": "2020.2",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Initialize pattern implementation.",
   "author": {
@@ -17,6 +17,5 @@
   "licensesUrl": "https://github.com/unity-game-framework/ugf-initialize/blob/master/license",
   "publishConfig": {
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
-  },
-  "dependencies": {}
+  }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {
       "name": "Unity Game Framework",
-      "url": "https://api.bintray.com/npm/unity-game-framework/public",
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default",
       "scopes": [
         "com.ugf"
       ]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,27 +7,27 @@
       "dependencies": {}
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.3",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
     m_Capabilities: 7
   - m_Id: scoped:Unity Game Framework
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_IsDefault: 0
@@ -38,14 +38,14 @@ MonoBehaviour:
     m_Original:
       m_Id: scoped:Unity Game Framework
       m_Name: Unity Game Framework
-      m_Url: https://api.bintray.com/npm/unity-game-framework/public
+      m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
       m_Scopes:
       - com.ugf
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_SelectedScopeIndex: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.3.16f1
+m_EditorVersionWithRevision: 2020.3.16f1 (049d6eca3c44)


### PR DESCRIPTION
- Update package publish registry.
- Update package _Unity_ version to `2020.3`.
- Add `IInitializeCollection.Create<T>()` method as shortcut for creation into collection.
- Add `IInitializeCollection.TryGet<TArguments, T>()` method to get item from collection using specified predicate.